### PR TITLE
Rework menu/preset file filtering and extract reveal functions

### DIFF
--- a/RightClickExplorer/Main.cs
+++ b/RightClickExplorer/Main.cs
@@ -95,23 +95,16 @@ namespace ShiftClickExplorer
 #if DEBUG
 						logger.LogDebug($"Key was pressed, checking {menu}");
 #endif
-						foreach (string s in GetMenuFilePaths(menu))
+
+						if (Modifier1)
 						{
-							if (File.Exists(s))
-							{
-#if DEBUG
-								logger.LogDebug($"Opening window at {s}");
-#endif
-								if (Modifier2)
-								{
-									Process.Start(s);
-								}
-								else
-								{
-									Process.Start("explorer.exe", "/select, " + s);
-								}
-							}
+							RevealMenuFileInFileExplorer(menu);
 						}
+						else if (Modifier2)
+						{
+							OpenMenuFile(menu);
+						}
+
 #if DEBUG
 						logger.LogDebug($"Done, copying {menu} to clipboard...");
 #endif
@@ -139,18 +132,7 @@ namespace ShiftClickExplorer
 #if DEBUG
 					logger.LogDebug($"Current selected preset {presetName}");
 #endif
-
-					foreach (string s in GetPresetFilePaths(presetName))
-					{
-						if (File.Exists(s))
-						{
-#if DEBUG
-							logger.LogDebug($"Opening window at {s}");
-#endif
-							Process.Start("explorer.exe", "/select, " + s);
-						}
-					}
-
+					RevealPresetFileInFileExplorer(presetName);
 #if DEBUG
 					logger.LogDebug($"Done, copying {presetName} to clipboard...");
 #endif
@@ -223,6 +205,63 @@ namespace ShiftClickExplorer
 			}
 
 			return presets;
+		}
+
+		public static void RevealMenuFileInFileExplorer(string menuFile)
+		{
+			if (menuFile.IsNullOrWhiteSpace())
+			{
+				return;
+			}
+
+			foreach (string s in GetMenuFilePaths(menuFile))
+			{
+				if (File.Exists(s))
+				{
+#if DEBUG
+					logger.LogDebug($"Opening window at {s}");
+#endif
+					Process.Start("explorer.exe", "/select, " + s);
+				}
+			}
+		}
+
+		public static void OpenMenuFile(string menuFile)
+		{
+			if (menuFile.IsNullOrWhiteSpace())
+			{
+				return;
+			}
+
+			foreach (string s in GetMenuFilePaths(menuFile))
+			{
+				if (File.Exists(s))
+				{
+#if DEBUG
+					logger.LogDebug($"Opening window at {s}");
+#endif
+					Process.Start(s);
+				}
+			}
+		}
+
+		public static void RevealPresetFileInFileExplorer(string presetFile)
+		{
+			if (presetFile.IsNullOrWhiteSpace())
+			{
+				return;
+			}
+
+			foreach (string s in GetPresetFilePaths(presetFile))
+			{
+				if (File.Exists(s))
+				{
+#if DEBUG
+					logger.LogDebug($"Opening window at {s}");
+#endif
+					Process.Start("explorer.exe", "/select, " + s);
+				}
+			}
 		}
 
 		public static void CopyToClipboard(string s)

--- a/RightClickExplorer/Main.cs
+++ b/RightClickExplorer/Main.cs
@@ -28,6 +28,17 @@ namespace ShiftClickExplorer
 		private static Lookup<string, string> filesLookup;
 		private static Lookup<string, string> presetsLookup;
 
+		private static Lookup<string, string> FilesLookup =>
+			filesLookup ?? (filesLookup =
+				(Lookup<string, string>)Directory.GetFiles(Paths.GameRootPath + "\\Mod", "*.*", SearchOption.AllDirectories)
+					.Where(t => t.ToLower().EndsWith(".menu") || t.ToLower().EndsWith(".mod"))
+					.ToLookup(path => Path.GetFileName(path), path => path, StringComparer.OrdinalIgnoreCase));
+
+		private static Lookup<string, string> PresetsLookup =>
+			presetsLookup ?? (presetsLookup =
+				(Lookup<string, string>)Directory.GetFiles(Paths.GameRootPath + "\\Preset", "*.preset", SearchOption.AllDirectories)
+					.ToLookup(presetPath => Path.GetFileName(presetPath), presetPath => presetPath, StringComparer.OrdinalIgnoreCase));
+
 		public void Awake()
 		{
 			harmony = Harmony.CreateAndPatchAll(typeof(Main));
@@ -83,14 +94,7 @@ namespace ShiftClickExplorer
 #if DEBUG
 						logger.LogDebug($"Key was pressed, checking {menu}");
 #endif
-						if (filesLookup == null)
-						{
-							filesLookup = (Lookup<string, string>)Directory.GetFiles(Paths.GameRootPath + "\\Mod", "*.*", SearchOption.AllDirectories)
-								.Where(t => t.ToLower().EndsWith(".menu") || t.ToLower().EndsWith(".mod"))
-								.ToLookup(path => Path.GetFileName(path), path => path, StringComparer.OrdinalIgnoreCase);
-						}
-
-						var files = filesLookup[menu];
+						var files = FilesLookup[menu];
 #if DEBUG
 						logger.LogDebug($"Checking file count of: {menu}");
 #endif
@@ -155,14 +159,7 @@ namespace ShiftClickExplorer
 #if DEBUG
 					logger.LogDebug($"Current selected preset {presetName}");
 #endif
-					if (presetsLookup == null)
-					{
-						presetsLookup = (Lookup<string, string>)Directory
-							.GetFiles(Paths.GameRootPath + "\\Preset", "*.preset", SearchOption.AllDirectories)
-							.ToLookup(presetPath => Path.GetFileName(presetPath), presetPath => presetPath, StringComparer.OrdinalIgnoreCase);
-					}
-
-					var presets = presetsLookup[presetName];
+					var presets = PresetsLookup[presetName];
 
 #if DEBUG
 					logger.LogDebug($"Checking file count of: {presetName}");

--- a/RightClickExplorer/Main.cs
+++ b/RightClickExplorer/Main.cs
@@ -16,7 +16,7 @@ using UnityEngine;
 
 namespace ShiftClickExplorer
 {
-	[BepInPlugin("ShiftClickExplorer", "ShiftClickExplorer", "1.3.1")]
+	[BepInPlugin("ShiftClickExplorer", "ShiftClickExplorer", "1.4.0")]
 	public class Main : BaseUnityPlugin
 	{
 		internal static ManualLogSource logger;

--- a/RightClickExplorer/Main.cs
+++ b/RightClickExplorer/Main.cs
@@ -24,12 +24,13 @@ namespace ShiftClickExplorer
 		public static ConfigEntry<KeyboardShortcut> ModifierKey2;
 		internal static readonly TextEditor editor = new TextEditor();
 
+		private static Harmony harmony;
 		static string[] Files;
 		static string[] Presets;
 
 		public void Awake()
 		{
-			Harmony.CreateAndPatchAll(typeof(Main));
+			harmony = Harmony.CreateAndPatchAll(typeof(Main));
 
 			logger = this.Logger;
 
@@ -37,13 +38,24 @@ namespace ShiftClickExplorer
 
 			ModifierKey2 = Config.Bind("General", "Open File", new KeyboardShortcut(KeyCode.LeftShift, KeyCode.LeftControl), "The key to hold while clicking a menu item for shift-click explorer. This one opens the file itself if available.");
 
-			UnityEngine.SceneManagement.SceneManager.sceneLoaded += (s, e) =>
+			UnityEngine.SceneManagement.SceneManager.sceneLoaded += OnSceneLoaded;
+		}
+
+		private void OnSceneLoaded(UnityEngine.SceneManagement.Scene s, UnityEngine.SceneManagement.LoadSceneMode e)
+		{
+			if (s.name.Equals("SceneEdit"))
 			{
-				if (s.name.Equals("SceneEdit"))
-				{
-					Files = null;
-				}
-			};
+				Files = null;
+				Presets = null;
+			}
+		}
+
+		private void OnDestroy()
+		{
+			Files = null;
+			Presets = null;
+			harmony?.UnpatchSelf();
+			UnityEngine.SceneManagement.SceneManager.sceneLoaded -= OnSceneLoaded;
 		}
 
 		[HarmonyPatch(typeof(SceneEdit), "ClickCallback")]

--- a/RightClickExplorer/Main.cs
+++ b/RightClickExplorer/Main.cs
@@ -3,6 +3,7 @@ using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -94,43 +95,22 @@ namespace ShiftClickExplorer
 #if DEBUG
 						logger.LogDebug($"Key was pressed, checking {menu}");
 #endif
-						var files = FilesLookup[menu];
-#if DEBUG
-						logger.LogDebug($"Checking file count of: {menu}");
-#endif
-
-						if (files.Count() > 0)
+						foreach (string s in GetMenuFilePaths(menu))
 						{
+							if (File.Exists(s))
+							{
 #if DEBUG
-							logger.LogDebug($"{menu} does exist in mod directory....");
+								logger.LogDebug($"Opening window at {s}");
 #endif
-
-							if (files.Count() > 1)
-							{
-								logger.LogWarning($"{menu} has duplicates in your mod directory! Multiple windows will open as a result.");
-							}
-
-							foreach (string s in files)
-							{
-								if (File.Exists(s))
+								if (Modifier2)
 								{
-#if DEBUG
-									logger.LogDebug($"Opening window at {s}");
-#endif
-									if (Modifier2)
-									{
-										Process.Start(s);
-									}
-									else
-									{
-										Process.Start("explorer.exe", "/select, " + s);
-									}
+									Process.Start(s);
+								}
+								else
+								{
+									Process.Start("explorer.exe", "/select, " + s);
 								}
 							}
-						}
-						else
-						{
-							logger.LogInfo($"{menu} may not be a mod file or it isn't found in the Mod directory. The file name will be copied to your clipboard instead!");
 						}
 #if DEBUG
 						logger.LogDebug($"Done, copying {menu} to clipboard...");
@@ -159,40 +139,18 @@ namespace ShiftClickExplorer
 #if DEBUG
 					logger.LogDebug($"Current selected preset {presetName}");
 #endif
-					var presets = PresetsLookup[presetName];
 
-#if DEBUG
-					logger.LogDebug($"Checking file count of: {presetName}");
-#endif
-
-					if (presets.Count() > 0)
+					foreach (string s in GetPresetFilePaths(presetName))
 					{
-#if DEBUG
-						logger.LogDebug($"{presetName} does exist in preset directory....");
-#endif
-
-						if (presets.Count() > 1)
+						if (File.Exists(s))
 						{
-							logger.LogWarning(
-								$"{presetName} has duplicates in your preset directory! Multiple windows will open as a result.");
-						}
-
-						foreach (string s in presets)
-						{
-							if (File.Exists(s))
-							{
 #if DEBUG
-								logger.LogDebug($"Opening window at {s}");
+							logger.LogDebug($"Opening window at {s}");
 #endif
-								Process.Start("explorer.exe", "/select, " + s);
-							}
+							Process.Start("explorer.exe", "/select, " + s);
 						}
 					}
-					else
-					{
-						logger.LogInfo(
-							$"{presetName} may not be a mod file or it isn't found in the Mod directory. The file name will be copied to your clipboard instead!");
-					}
+
 #if DEBUG
 					logger.LogDebug($"Done, copying {presetName} to clipboard...");
 #endif
@@ -203,8 +161,70 @@ namespace ShiftClickExplorer
 			}
 			return true;
 		}
-		
-		
+
+		private static IEnumerable<string> GetMenuFilePaths(string menu)
+		{
+			if (menu.IsNullOrWhiteSpace())
+			{
+				return Enumerable.Empty<string>();
+			}
+
+			var files = FilesLookup[menu];
+#if DEBUG
+			logger.LogDebug($"Checking file count of: {menu}");
+#endif
+
+			if (files.Count() > 0)
+			{
+#if DEBUG
+				logger.LogDebug($"{menu} does exist in mod directory....");
+#endif
+
+				if (files.Count() > 1)
+				{
+					logger.LogWarning($"{menu} has duplicates in your mod directory! Multiple windows will open as a result.");
+				}
+			}
+			else
+			{
+				logger.LogInfo($"{menu} may not be a mod file or it isn't found in the Mod directory. The file name will be copied to your clipboard instead!");
+			}
+
+			return files;
+		}
+
+		private static IEnumerable<string> GetPresetFilePaths(string presetName)
+		{
+			if (presetName.IsNullOrWhiteSpace())
+			{
+				return Enumerable.Empty<string>();
+			}
+
+			var presets = PresetsLookup[presetName];
+
+#if DEBUG
+			logger.LogDebug($"Checking file count of: {presetName}");
+#endif
+
+			if (presets.Count() > 0)
+			{
+#if DEBUG
+				logger.LogDebug($"{presetName} does exist in preset directory....");
+#endif
+
+				if (presets.Count() > 1)
+				{
+					logger.LogWarning($"{presetName} has duplicates in your preset directory! Multiple windows will open as a result.");
+				}
+			}
+			else
+			{
+				logger.LogInfo($"{presetName} may not be a mod file or it isn't found in the Mod directory. The file name will be copied to your clipboard instead!");
+			}
+
+			return presets;
+		}
+
 		public static void CopyToClipboard(string s)
 		{
 			editor.text = s;


### PR DESCRIPTION
A `Lookup<TKey, TElement>` was used instead of filtering an array of paths because it essentially does the same thing but at initialization and accessing these paths is as easy as providing the filename. I also set the presets lookup to null when entering edit mode just like with the menu files which I felt was an oversight. Adding support for script engine is just a nicety given there isn't a lot of cleanup required.

The big thing is extracting the reveal functions and most of the work done was just extracting the logic from the patch functions. I opted to bump the minor version to indicate the availability of these new reveal functions so the plugin's version is `1.4.0` now.